### PR TITLE
User defninition of API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,22 @@ Full results are printed to screen, and can be written to file with the `-o` fla
 python3 swamp.py -id UA-6888464-2 -o myOutputFile.txt
 ```
 
-To use SpyOnWeb, include the `-spyonweb` flag, and set the API token with `-token`.
+To use SpyOnWeb, first edit line 14 of `swamp.py` to provide your SpyOnWeb API Key:
+```python
+# USER API KEYS
+SPY_ON_WEB_API_KEY="Your API Key Here"
+```
+
+You can then include the `-spyonweb` flag on the command line.
 ```bash
-python3 swamp.py -id UA-6888464-2 -spyonweb -token YOUR_API_TOKEN
+python3 swamp.py -id UA-6888464-2 -spyonweb
 ```
 
 Additionally, you can use swamp.py in your own python script.
 ```python
 import swamp
 Swamp = swamp.Swamp() # init Swamp object (by default uses urlscan.io)
-Swamp = swamp.Swamp(api="spyonweb",token="YOUR_API_TOKEN") # init Swamp object to use SpyOnWeb
+Swamp = swamp.Swamp(api="spyonweb") # init Swamp object to use SpyOnWeb
 associated_urls = Swamp.run(id="UA-12345-1") # list of unique urls associated with the tracking ID UA-12345-1
 associated_urls = Swamp.run(url="infowars.com") # list of unique urls associated with the tracking ID(s) found on infowars.com
 

--- a/swamp.py
+++ b/swamp.py
@@ -7,9 +7,11 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from colorama import init
 from colorama import Fore, Back, Style
 from datetime import datetime
-
 # disable warning HTTPS
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+# USER API KEYS
+SPY_ON_WEB_API_KEY=""
 
 class Swamp(object):
 
@@ -17,10 +19,17 @@ class Swamp(object):
         self.cli = cli
         self.outfile = outfile
         self.api = api
-        self.api_key = token
         # ensure api_key is given if needed
         if self.api == "spyonweb":
-            assert self.api_key != None, "SpyOnWeb Requires and API Key."
+            # if a token is passed in, use it (allows me to test without putting my key on the internet)
+            if token != None:
+                self.api_key = token
+            # if not use the user-defined one
+            else:
+                self.api_key = SPY_ON_WEB_API_KEY
+            
+            # ensure that an api key is given
+            assert self.api_key != None and self.api_key != "", "SpyOnWeb Requires and API Key. Set 'SPY_ON_WEB_API_KEY' at the top of swamp.py"
 
     def run(self,id=None,url=None):
         gid = id


### PR DESCRIPTION
Easily allows users to place their SpyOnWeb API Key in the swamp.py file so they do not have to supply it each time the program is run.
```python
# USER API KEYS
SPY_ON_WEB_API_KEY=""
```
The Swamp object will take a passed-in token as highest precedent, but will default to the global variable. But if no token is passed in, and `SPY_ON_WEB_API_KEY` is still an empty string, the program will halt, and inform the user to define `SPY_ON_WEB_API_KEY`.
```python
if self.api == "spyonweb":
            # if a token is passed in, use it (allows me to test without putting my key on the internet)
            if token != None:
                self.api_key = token
            # if not use the user-defined one
            else:
                self.api_key = SPY_ON_WEB_API_KEY

            # ensure that an api key is given
            assert self.api_key != None and self.api_key != "", "SpyOnWeb Requires and API Key. Set 'SPY_ON_WEB_API_KEY' at the top of swamp.py"```