### PR TITLE
Improve request failure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,35 @@ Full results are printed to screen, and can be written to file with the `-o` fla
 python3 swamp.py -id UA-6888464-2 -o myOutputFile.txt
 ```
 
+You can control what API(s) Swamp will use by suppliying the `-urlscan` and/or `-spyonweb` flags, such as
+```bash
+python3 swamp.py -id UA-6888464-2 -urlscan -spyonweb
+```
+
+By default, Swamp will attempt to use both urlscan.io and SpyOnWeb.
+
 To use SpyOnWeb, first edit line 14 of `swamp.py` to provide your SpyOnWeb API Key:
 ```python
 # USER API KEYS
 SPY_ON_WEB_API_KEY="Your API Key Here"
 ```
-
-You can then include the `-spyonweb` flag on the command line.
-```bash
-python3 swamp.py -id UA-6888464-2 -spyonweb
-```
+Without this, Swamp will skip any query of SpyOnWeb.
 
 Additionally, you can use swamp.py in your own python script.
 ```python
-import swamp
-Swamp = swamp.Swamp() # init Swamp object (by default uses urlscan.io)
-Swamp = swamp.Swamp(api="spyonweb") # init Swamp object to use SpyOnWeb
-associated_urls = Swamp.run(id="UA-12345-1") # list of unique urls associated with the tracking ID UA-12345-1
-associated_urls = Swamp.run(url="infowars.com") # list of unique urls associated with the tracking ID(s) found on infowars.com
+>>> import swamp
+>>> Swamp = swamp.Swamp() # init Swamp object (by default uses urlscan.io)
+>>> Swamp = swamp.Swamp(api="spyonweb") # init Swamp object to use SpyOnWeb
+>>> Swamp = swamp.Swamp(api=["urlscan","spyonweb"]) # init Swamp object to use SpyOnWeb and urlscan.io
+>>> Swamp = swamp.Swamp(api="all") # init Swamp object to use all available APIs
+>>> results = Swamp.run(id="UA-12345-1")
+>>> results
+{"urlscan":["url1", "url2", "url3"], "spyonweb":["url1", "url2", "url3"]}
+>>> results = Swamp.run(url="infowars.com")
+>>> results
+{"UA-12345-1":{"urlscan":["url1", "url2", "url3"], "spyonweb":["url1", "url2", "url3"]}, "UA-67789-1":{"urlscan":["url1", "url2", "url3"], "spyonweb":["url1", "url2", "url3"]}
 
-associated_domains = Swamp.urls_to_domains(associated_urls) # reduces the list of urls to a list of unique domains
+>>> associated_domains = Swamp.urls_to_domains(associated_urls) # reduces the list of urls to a list of unique domains
 ```
 
 Test scripts are included.

--- a/swamp.py
+++ b/swamp.py
@@ -108,7 +108,12 @@ class Swamp(object):
     def validate_url(self,url):
         if self.cli:
             print(Fore.GREEN + "Validating {}".format(url))
-        check = requests.head(url)
+        try:
+            check = requests.head(url)
+        except requests.exceptions.ConnectionError:
+            print(Fore.RED + "Unable to access {}".format(url) + Style.RESET_ALL)
+            return False
+
         if check.status_code < 400:
             # if redirected, return the redirected url
             if check.status_code // 100 == 3:

--- a/test.py
+++ b/test.py
@@ -12,17 +12,21 @@ spyonweb_token = args.spyonweb_token
 print("Testing urlscan.io (default)")
 Swamp = swamp.Swamp()
 output = Swamp.run(id=test_id)
-assert len(output) > 0, "FAILED ON URLSCAN (default) WITH ID"
+print(output['urlscan'])
+assert len(output['urlscan']) > 0, "FAILED ON URLSCAN (default) WITH ID"
 output = Swamp.run(url=test_url)
-assert len(output) > 0, "FAILED ON URLSCAN (default) WITH URL"
+print(output['UA-6888464-2']['urlscan'])
+assert len(output['UA-6888464-2']['urlscan']) > 0, "FAILED ON URLSCAN (default) WITH URL"
 print("SUCCESS.\n\n")
 
 print("Testing urlscan.io (explicit call)")
 Swamp = swamp.Swamp(api="urlscan")
 output = Swamp.run(id=test_id)
-assert len(output) > 0, "FAILED ON URLSCAN (explicit) WITH ID"
+print(output['urlscan'])
+assert len(output['urlscan']) > 0, "FAILED ON URLSCAN (explicit) WITH ID"
 output = Swamp.run(url=test_url)
-assert len(output) > 0, "FAILED ON URLSCAN (explicit) WITH URL"
+print(output['UA-6888464-2']['urlscan'])
+assert len(output['UA-6888464-2']['urlscan']) > 0, "FAILED ON URLSCAN (explicit) WITH URL"
 print("SUCCESS.\n\n")
 
 if spyonweb_token == None:
@@ -31,8 +35,40 @@ else:
     print("Testing SpyOnWeb")
     Swamp = swamp.Swamp(api="spyonweb",token=spyonweb_token)
     output = Swamp.run(id=test_id)
-    assert len(output) > 0, "FAILED ON SPYONWEB WITH ID"
+    print(output['spyonweb'])
+    assert len(output['spyonweb']) > 0, "FAILED ON SPYONWEB WITH ID"
     output = Swamp.run(url=test_url)
-    assert len(output) > 0, "FAILED ON SPYONWEB WITH URL"
+    print(output['UA-6888464-2']['spyonweb'])
+    assert len(output['UA-6888464-2']['spyonweb']) > 0, "FAILED ON SPYONWEB WITH URL"
     print("SUCCESS.\n\n")
+
+    print("Testing Both through 'all'")
+    Swamp = swamp.Swamp(api="all",token=spyonweb_token)
+    output = Swamp.run(id=test_id)
+    print(output['spyonweb'])
+    assert len(output['spyonweb']) > 0, "FAILED ON SPYONWEB WITH ID"
+    print(output['urlscan'])
+    assert len(output['urlscan']) > 0, "FAILED ON URLSCAN WITH ID"
+    output = Swamp.run(url=test_url)
+    print(output['UA-6888464-2']['spyonweb'])
+    assert len(output['UA-6888464-2']['spyonweb']) > 0, "FAILED ON SPYONWEB WITH URL"
+    print(output['UA-6888464-2']['urlscan'])
+    assert len(output['UA-6888464-2']['urlscan']) > 0, "FAILED ON URLSCAN WITH URL"
+    print("SUCCESS.\n\n")
+
+    print("Testing Both through list")
+    Swamp = swamp.Swamp(api=['urlscan','spyonweb'],token=spyonweb_token)
+    output = Swamp.run(id=test_id)
+    print(output['spyonweb'])
+    assert len(output['spyonweb']) > 0, "FAILED ON SPYONWEB WITH ID"
+    print(output['urlscan'])
+    assert len(output['urlscan']) > 0, "FAILED ON URLSCAN WITH ID"
+    output = Swamp.run(url=test_url)
+    print(output['UA-6888464-2']['spyonweb'])
+    assert len(output['UA-6888464-2']['spyonweb']) > 0, "FAILED ON SPYONWEB WITH URL"
+    print(output['UA-6888464-2']['urlscan'])
+    assert len(output['UA-6888464-2']['urlscan']) > 0, "FAILED ON URLSCAN WITH URL"
+    print("SUCCESS.\n\n")
+
+
 

--- a/test.sh
+++ b/test.sh
@@ -4,16 +4,10 @@ spyonweb_token=$1
 test_id=UA-6888464-2
 test_url=infowars.com
 
-echo "Testing urlscan.io (default) with -id"
-python swamp.py -id $test_id
-echo
-echo "Testing urlscan.io (default) with -url"
-python swamp.py -url $test_url
-
-echo "Testing urlscan.io (explicit) with -id"
+echo "Testing urlscan.io with -id"
 python swamp.py -id $test_id -urlscan
 echo
-echo "Testing urlscan.io (explicit) with -url"
+echo "Testing urlscan.io with -url"
 python swamp.py -url $test_url -urlscan
 
 
@@ -22,3 +16,11 @@ python swamp.py -id $test_id -spyonweb -token $spyonweb_token
 echo
 echo "Testing SpyOnWeb with -url"
 python swamp.py -url $test_url -spyonweb -token $spyonweb_token
+
+echo
+echo "Testing SpyOnWeb and urlscan.io (explicit) with -id"
+python swamp.py -id $test_id -spyonweb -urlscan -token $spyonweb_token
+echo
+echo "Testing SpyOnWeba and urlscan.io (default) with -id"
+python swamp.py -id $test_id -token $spyonweb_token
+


### PR DESCRIPTION
Instead of relying solely on request status codes, properly fail the url validation on a `requests.exceptions.ConnectionError`.